### PR TITLE
APM-4115: Update keycloak paths

### DIFF
--- a/user-restricted-separate-auth-tutorials/cis2/csharp/HelloWorldSeparateAuth/README.md
+++ b/user-restricted-separate-auth-tutorials/cis2/csharp/HelloWorldSeparateAuth/README.md
@@ -54,7 +54,7 @@ To run the example tutorial, you need to set the following environment variables
 |------------------------------|-------------------------------------------------------------------------------|
 | `KEYCLOAK_CLIENT_ID`         | `test-client-cis2`                                                            |
  | `KEYCLOAK_CLIENT_SECRET`     | `d32d122e-8f65-4077-bb34-14ac4c2c3b41`                                                                            |
-| `KEYCLOAK_AUTHORITY`         | `https://identity.ptl.api.platform.nhs.uk/auth/realms/NHS-Login-mock-sandbox` |
+| `KEYCLOAK_AUTHORITY`         | `https://identity.ptl.api.platform.nhs.uk/realms/NHS-Login-mock-sandbox` |
  | `KEYCLOAK_PRIVATE_KEY_PATH`  | The path to your private key for the Keycloak realm                           | 
  | `OAUTH_ENDPOINT`             | `https://sandbox.api.service.nhs.uk/oauth2-mock`                              |
  | `ENDPOINT`                   | `https://sandbox.api.service.nhs.uk/hello-world/hello/user`                   |

--- a/user-restricted-separate-auth-tutorials/cis2/java/env.sample
+++ b/user-restricted-separate-auth-tutorials/cis2/java/env.sample
@@ -1,4 +1,4 @@
-export PROVIDER_OAUTH_ENDPOINT=https://identity.ptl.api.platform.nhs.uk/auth/realms/Cis2-mock-sandbox/protocol/openid-connect
+export PROVIDER_OAUTH_ENDPOINT=https://identity.ptl.api.platform.nhs.uk/realms/Cis2-mock-sandbox/protocol/openid-connect
 export PROVIDER_CLIENT_ID=hello-world-tutorials
 export PROVIDER_CLIENT_SECRET=dde091bb-97af-483e-8d3e-02d6592cf318
 export PROVIDER_REDIRECT_URI=http://localhost:8080/callback

--- a/user-restricted-separate-auth-tutorials/cis2/php/src/Controller/HelloAuthController.php
+++ b/user-restricted-separate-auth-tutorials/cis2/php/src/Controller/HelloAuthController.php
@@ -29,8 +29,8 @@ class HelloAuthController extends AbstractController {
             'clientId'                => 'hello-world-tutorials' ,    // The client ID assigned to you by the provider 
             'client_secret'           => 'dde091bb-97af-483e-8d3e-02d6592cf318',
             'redirectUri'             => 'http://localhost:8000/hello',
-            'urlAuthorize'            => 'https://identity.ptl.api.platform.nhs.uk/auth/realms/Cis2-mock-sandbox/protocol/openid-connect/auth',
-            'urlAccessToken'          => 'https://identity.ptl.api.platform.nhs.uk/auth/realms/Cis2-mock-sandbox/protocol/openid-connect/token',
+            'urlAuthorize'            => 'https://identity.ptl.api.platform.nhs.uk/realms/Cis2-mock-sandbox/protocol/openid-connect/auth',
+            'urlAccessToken'          => 'https://identity.ptl.api.platform.nhs.uk/realms/Cis2-mock-sandbox/protocol/openid-connect/token',
             'scopes' => ['openid', 'nationalrbacaccess'], 
             'urlResourceOwnerDetails' => ''
         ]);
@@ -50,7 +50,7 @@ class HelloAuthController extends AbstractController {
         
         $code = $_GET['code'];
         $IStokenUrl = 'https://sandbox.api.service.nhs.uk/oauth2-mock/token';
-        $tokenUrl = 'https://identity.ptl.api.platform.nhs.uk/auth/realms/Cis2-mock-sandbox/protocol/openid-connect/token';
+        $tokenUrl = 'https://identity.ptl.api.platform.nhs.uk/realms/Cis2-mock-sandbox/protocol/openid-connect/token';
         
         $APPPrivateKey_path = $_ENV['CLIENT_ID'];
         $APPClientSecret = $_ENV['CLIENT_SECRET'];

--- a/user-restricted-separate-auth-tutorials/nhs-login/csharp/HelloWorldSeparateAuth/README.md
+++ b/user-restricted-separate-auth-tutorials/nhs-login/csharp/HelloWorldSeparateAuth/README.md
@@ -52,7 +52,7 @@ To run the example tutorial, you need to set the following environment variables
 | Variable name               | Description                                                                                                                        |
 |-----------------------------|------------------------------------------------------------------------------------------------------------------------------------|
 | `KEYCLOAK_CLIENT_ID`        | `test-client-nhs-login`                                                                                                            |
-| `KEYCLOAK_AUTHORITY`        | `https://identity.ptl.api.platform.nhs.uk/auth/realms/NHS-Login-mock-sandbox`                                                      |
+| `KEYCLOAK_AUTHORITY`        | `https://identity.ptl.api.platform.nhs.uk/realms/NHS-Login-mock-sandbox`                                                      |
  | `KEYCLOAK_PRIVATE_KEY_PATH` | The path to the provider key. NHS login will provide this key, but for this tutorial you can use a our mock NHS login provider key | 
  | `OAUTH_ENDPOINT`            | `https://sandbox.api.service.nhs.uk/oauth2-mock`                                                                                   |
  | `ENDPOINT`                  | `https://sandbox.api.service.nhs.uk/hello-world/hello/user`                                                                        |

--- a/user-restricted-separate-auth-tutorials/nhs-login/php/src/Controller/HelloAuthController.php
+++ b/user-restricted-separate-auth-tutorials/nhs-login/php/src/Controller/HelloAuthController.php
@@ -27,8 +27,8 @@ class HelloAuthController extends AbstractController {
         $provider = new \League\OAuth2\Client\Provider\GenericProvider([
             'clientId'                => 'hello-world-tutorials' ,    // The client ID assigned to you by the provider 
             'redirectUri'             => 'http://localhost:8000/hello',
-            'urlAuthorize'            => 'https://identity.ptl.api.platform.nhs.uk/auth/realms/NHS-Login-mock-sandbox/protocol/openid-connect/auth',
-            'urlAccessToken'          => 'https://identity.ptl.api.platform.nhs.uk/auth/realms/NHS-Login-mock-sandbox/protocol/openid-connect/token',
+            'urlAuthorize'            => 'https://identity.ptl.api.platform.nhs.uk/realms/NHS-Login-mock-sandbox/protocol/openid-connect/auth',
+            'urlAccessToken'          => 'https://identity.ptl.api.platform.nhs.uk/realms/NHS-Login-mock-sandbox/protocol/openid-connect/token',
             'scopes' => ['openid', 'profile'], 
             'urlResourceOwnerDetails' => ''
         ]);
@@ -52,7 +52,7 @@ class HelloAuthController extends AbstractController {
         // FILL THESE VARIABLES
         // Please remove the extension from the file auth.
         $key_path = '/app/auth.key';
-        $tokenUrl = 'https://identity.ptl.api.platform.nhs.uk/auth/realms/NHS-Login-mock-sandbox/protocol/openid-connect/token';
+        $tokenUrl = 'https://identity.ptl.api.platform.nhs.uk/realms/NHS-Login-mock-sandbox/protocol/openid-connect/token';
         $clientId = 'hello-world-tutorials';
 
         $APPPrivateKey_path = $_ENV['CLIENT_ID'];


### PR DESCRIPTION
Do not merge until Keycloak has been upgraded (see APM-3862)

The /auth/ component will be removed from these keycloak paths following the keycloak upgrade