### PR TITLE
APM-7388-pin-all-actions-to-a-commit-sha

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR pins all below Actions to a Commit SHA to adhere to the latest best practices based on [software-engineering-quality-framework/practices/actions-best-practices.md](https://github.com/NHSDigital/software-engineering-quality-framework/blob/main/practices/actions-best-practices.md#third-party-actions)